### PR TITLE
Diagnose server start error: cmd not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,4 @@ EXPOSE 8080
 
 # Run the jar using sh -c (avoids PATH issues)
 CMD ["sh", "-c", "java -jar target/*.jar"]
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,7 +27,7 @@ spring.mail.properties.mail.debug=true
 
 # Server Configuration
 server.address=0.0.0.0
-server.port=8080
+server.port=${PORT:8080}
 
 
 # Logging


### PR DESCRIPTION
Rename `DockerFile` to `Dockerfile` and update `server.port` to use the `PORT` environment variable to fix server startup issues on deployment platforms.

The `DockerFile` was misnamed (capital F), which caused deployment platforms to ignore it and misinterpret "CMD" as a literal executable, leading to server startup failures. Additionally, updating `server.port` to `server.port=${PORT:8080}` ensures the application correctly binds to dynamically assigned ports on platforms like Render or Heroku.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac287b31-8e0c-4951-be81-6589adfd40eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac287b31-8e0c-4951-be81-6589adfd40eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

